### PR TITLE
Expose PageLink and showLink

### DIFF
--- a/src/Yesod/Paginator/Widget.hs
+++ b/src/Yesod/Paginator/Widget.hs
@@ -9,6 +9,8 @@ module Yesod.Paginator.Widget
  , defaultPageWidgetConfig
  , PageWidget
  , PageWidgetConfig(..)
+ , PageLink(..)
+ , showLink
  ) where
 
 import Yesod


### PR DESCRIPTION
These _seem_ internal, but by not exposing them, it means that end-users
need to re-implement a decent amount of existing logic in order to
create custom pagination widgets easily. By exposing these to our users,
we can make their lives a little bit easier.